### PR TITLE
Speeding up regeneration after changing iterations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project (MandelExplorer CXX)
 # Version numbers
 set (MandelExplorer_VERSION_MAJOR 0)
 set (MandelExplorer_VERSION_MINOR 1)
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 
 # Adding extra libraries for displays and things
 set (EXTRA_LIBS ${EXTRA_LIBS} 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project (MandelExplorer CXX)
 # Version numbers
 set (MandelExplorer_VERSION_MAJOR 0)
 set (MandelExplorer_VERSION_MINOR 1)
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O3")
 
 # Adding extra libraries for displays and things
 set (EXTRA_LIBS ${EXTRA_LIBS} 

--- a/mandelbrotViewer.cpp
+++ b/mandelbrotViewer.cpp
@@ -104,11 +104,6 @@ void MandelbrotViewer::changePosView(sf::Vector2f new_center, double zoom_factor
 
 //generate the mandelbrot
 void MandelbrotViewer::generate() {
-    if (last_max_iter < max_iter) {
-        std::cout << "Iter increased\n";
-    } else if (last_max_iter > max_iter) {
-        std::cout << "Iter decreased\n";
-    }
 
     //make sure it starts at line 0
     nextLine = 0;

--- a/mandelbrotViewer.cpp
+++ b/mandelbrotViewer.cpp
@@ -2,6 +2,9 @@
 #include <string.h>
 #include <iostream>
 #include <ctime>
+//#include <thread>
+#include <memory>
+#include <vector>
 
 //initialize a couple of global objects
 sf::Mutex mutex1;
@@ -109,18 +112,23 @@ void MandelbrotViewer::generate() {
     nextLine = 0;
 
     // create the thread pool
-    std::vector<sf::Thread> threadPool;
+//    std::vector<std::thread> threadPool;
+//    std::vector<sf::Thread> threadPool;
+    std::vector< std::unique_ptr<sf::Thread> > threadPool;
     for (int i=0; i<THREAD_COUNT; i++) {
-        sf::Thread temp_thread(&MandelbrotViewer::genLine, this);
-        threadPool.push_back(temp_thread);
+//        std::thread t_thread([this]() {genLine();});
+        sf::Thread temp (&MandelbrotViewer::genLine, this);
+        threadPool.push_back(std::make_unique<sf::Thread> (sf::Thread (&MandelbrotViewer::genLine, this)));
+//        threadPool.push_back(std::make_unique<sf::Thread>( ));
+//        sf::Thread temp_thread(&MandelbrotViewer::genLine, this);
     }
-    // Launch all the threads
+    // Start the threads
     for (int i=0; i<THREAD_COUNT; i++) {
-        threadPool[i].launch();
+        threadPool.at(i)->launch();
     }
     // Close the threads
     for (int i=0; i<THREAD_COUNT; i++) {
-        threadPool[i].wait();
+        threadPool.at(i)->wait();
     }
 }
 

--- a/mandelbrotViewer.cpp
+++ b/mandelbrotViewer.cpp
@@ -57,7 +57,7 @@ sf::Vector2f MandelbrotViewer::getMandelbrotCenter() {
 
 //gets the next event from the viewer
 bool MandelbrotViewer::getEvent(sf::Event& event) {
-    return window->pollEvent(event);
+    return window->waitEvent(event);
 }
 
 //checks if the window is open
@@ -112,15 +112,15 @@ void MandelbrotViewer::generate() {
     std::vector<sf::Thread> threadPool;
     for (int i=0; i<THREAD_COUNT; i++) {
         sf::Thread temp_thread(&MandelbrotViewer::genLine, this);
-        threadPool.push_back<temp_thread>;
+        threadPool.push_back(temp_thread);
     }
     // Launch all the threads
     for (int i=0; i<THREAD_COUNT; i++) {
-        threadPool.at(i).launch();
+        threadPool[i].launch();
     }
     // Close the threads
     for (int i=0; i<THREAD_COUNT; i++) {
-        threadPool.at(i).wait();
+        threadPool[i].wait();
     }
 }
 

--- a/mandelbrotViewer.cpp
+++ b/mandelbrotViewer.cpp
@@ -139,7 +139,6 @@ void MandelbrotViewer::genLine() {
     double y_inc = interpolate(area.height, resolution);
     sf::Color color;
 
-    int count = 0;
     while(true) {
 
         //the mutex avoids multiple threads writing to variables at the same time,
@@ -150,7 +149,7 @@ void MandelbrotViewer::genLine() {
 
         //if all the rows have been generated, stop it from generating outside the bounds
         //of the image
-        if (row >= resolution) {std::cout << "Calculated " << count << " pixels\n"; return;}
+        if (row >= resolution) return;
 
         //calculate the row height in the complex plane
         y = area.top + row * y_inc;
@@ -166,12 +165,11 @@ void MandelbrotViewer::genLine() {
                 iter = max_iter;
             } // Check if we zoomed, or didn't change iterations which means we need to recalculate the whole thing
             else {
-                count++;
-
                 //calculate the next x coordinate of the complex plane
                 x = area.left + column * x_inc;
                 iter = escape(x, y);
             }
+
             //mutex this too so that the image is not accessed multiple times simultaneously
             mutex2.lock();
             image.setPixel(column, row, findColor(iter));

--- a/mandelbrotViewer.cpp
+++ b/mandelbrotViewer.cpp
@@ -122,6 +122,8 @@ void MandelbrotViewer::generate() {
     thread2.wait();
     thread3.wait();
     thread4.wait();
+
+    last_max_iter = max_iter;
 }
 
 //this is a private worker thread function. Each thread picks the next ungenerated
@@ -153,11 +155,11 @@ void MandelbrotViewer::genLine() {
         for (column = 0; column < resolution; column++) {
 
             // Check if we increased iterations and if the pixel already diverged
-            if ( last_max_iter < max_iter && image_array[row][column] != last_max_iter ) {
+            if ( last_max_iter < max_iter && image_array[row][column] < last_max_iter ) {
                 iter = image_array[row][column];
             } // Check if we decreased iterations and if the pixel already converged
-            else if ( last_max_iter > max_iter && image_array[row][column] == last_max_iter) {
-                iter = max_iter;
+            else if ( last_max_iter > max_iter && image_array[row][column] > max_iter) {
+                iter = image_array[row][column];
             } // Check if we zoomed, or didn't change iterations which means we need to recalculate the whole thing
             else {
                 //calculate the next x coordinate of the complex plane

--- a/mandelbrotViewer.h
+++ b/mandelbrotViewer.h
@@ -1,8 +1,6 @@
 #ifndef MANDELBROTVIEWER_H
 #define MANDELBROTVIEWER_H
 
-#define THREAD_COUNT    4
-
 #include <SFML/Graphics.hpp>
 #include <vector>
 

--- a/mandelbrotViewer.h
+++ b/mandelbrotViewer.h
@@ -29,7 +29,7 @@ class MandelbrotViewer {
         bool isOpen();
         
         //Setter functions:
-        void setIterations(int iter) {max_iter = iter;}
+        void setIterations(int iter) {last_max_iter = max_iter; max_iter = iter;}
         void setColorMultiple(double mult) {color_multiple = mult;}
         void setFramerate(int rate) {framerateLimit = rate;}
         void setColorScheme(int newScheme) {scheme = newScheme; initPalette();}
@@ -85,6 +85,7 @@ class MandelbrotViewer {
         //maximum number of iterations to check for. Higher values are slower,
         //but more precise
         int max_iter;
+        int last_max_iter;
 
         //Functions:
         

--- a/mandelbrotViewer.h
+++ b/mandelbrotViewer.h
@@ -1,6 +1,8 @@
 #ifndef MANDELBROTVIEWER_H
 #define MANDELBROTVIEWER_H
 
+#define THREAD_COUNT    4
+
 #include <SFML/Graphics.hpp>
 #include <vector>
 


### PR DESCRIPTION
Whenever you want to change the iteration, `genLine()` will first check if the pixel already diverged or converged, so that `escape()` does not need to be called excessive times. Also added `-O3` flag to CMake.
