### PR TITLE
detect supported concurrent threads (threadpool)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set (EXTRA_LIBS ${EXTRA_LIBS}
     sfml-system
     sfml-window
     sfml-graphics
+    pthread
 )
 
 add_executable (MandelExplorer

--- a/mandelbrotExplorer.cpp
+++ b/mandelbrotExplorer.cpp
@@ -1,5 +1,6 @@
 #include "mandelbrotViewer.h"
 #include <iostream>
+#include <thread>
 
 //global stuff
 int iterations = 100;
@@ -223,14 +224,13 @@ void handleZoom(MandelbrotViewer *brot, sf::Event *event){
 
     //start zooming with a worker thread, so that it can generate
     //the new image while it's zooming
-    sf::Thread thread(&zoom);
-    thread.launch();
+    std::thread thread(&zoom);
 
     //start generating while it's zooming
     brot->generate();
 
     //wait for the thread to finish (wait for the zoom to finish)
-    thread.wait();
+    thread.join();
 
     //now reactivate the window
     brot->setWindowActive(true);

--- a/mandelbrotViewer.h
+++ b/mandelbrotViewer.h
@@ -101,6 +101,9 @@ class MandelbrotViewer {
         //mandelbrot, then moves onto the next, until the entire mandelbrot is generated
         void genLine();
 
+        //Holds the maximum number of concurrent threads suppported by the current CPU
+        unsigned int max_threads;
+
         //This looks up a color to print according to the escape value given
         sf::Color findColor(int iter);
 


### PR DESCRIPTION
MandelbrotViewer constructor detects the number of concurrent threads supported by the CPU, then the member generate function uses a threadpool to implement it.

Using std::thread instead of sf::Thread now.

Closes #15 
