### PR TITLE
Interrupt, color lock, and iter/color scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ Click and Drag - ...click and drag
 Page Up - rotate counter clockwise  
 Page Down - rotate clockwise  
 Home - reset rotation  
+L - lock color   

--- a/mandelbrotExplorer.cpp
+++ b/mandelbrotExplorer.cpp
@@ -1,4 +1,5 @@
 #include "mandelbrotViewer.h"
+#include <chrono>
 #include <iostream>
 #include <thread>
 
@@ -7,22 +8,27 @@
 //this struct holds the parameters for the zoom function,
 //since it needs to be threaded and thus cannot accept arguments
 struct zoomParameters {
-    MandelbrotViewer *viewer;
+    MandelbrotViewer *brot;
     sf::Vector2f oldc;
     sf::Vector2f newc;
+    sf::Event event;
     double zoom;
     int frames;
+    bool done;
 } param;
 
 //returns range increments to get from min to max
 double interpolate(double min, double max, int range) { return (max-min)/range; }
 
 //function prototypes
+void handleEvent();
 void handleKeyboard(MandelbrotViewer *brot, sf::Event *event);
 void handleZoom(MandelbrotViewer *brot, sf::Event *event);
 void handleDrag(MandelbrotViewer *brot, sf::Event *event);
 void handleResize(MandelbrotViewer *brot, sf::Event *event);
 double handleRotate();
+void handleGenerate();
+void eventPoll();
 void zoom();
 
 int main() {
@@ -37,7 +43,8 @@ int main() {
     brot.refreshWindow();
 
     //point the zoom function to the 'brot' instance
-    param.viewer = &brot;
+    param.brot = &brot;
+    param.done = true;
 
     //create an event to test for input
     sf::Event event;
@@ -45,49 +52,55 @@ int main() {
     //main window loop
     while (brot.isOpen()) {
 
-        brot.getEvent(event);
+        brot.getEvent(param.event);
 
-        //this big switch statement handles all types of input
-        switch (event.type) {
-
-            //if the event is a keypress
-            case sf::Event::KeyPressed:
-                handleKeyboard(&brot, &event);
-                break;
-
-            //if the event is a mousewheel scroll, zoom
-            case sf::Event::MouseWheelScrolled:
-                handleZoom(&brot, &event);
-                break;
-
-            //if the event is a click, drag the view:
-            case sf::Event::MouseButtonPressed:
-                handleDrag(&brot, &event);
-                break;
-
-            //if the window regains focus, refresh it
-            case sf::Event::GainedFocus:
-                brot.refreshWindow();
-                break;
-
-            //if the event is a resize, handle it
-            case sf::Event::Resized:
-                handleResize(&brot, &event);
-                break;
-
-            //if the window is closed
-            case sf::Event::Closed:
-                brot.close();
-                break;
-
-            default:
-                break;
-        } //end event switch
+        handleEvent();
 
     } //end main window loop
 
     return 0;
 } //end main
+
+//this function handles all events
+void handleEvent() {
+    //this switch statement handles all types of input
+    switch (param.event.type) {
+
+        //if the event is a keypress
+        case sf::Event::KeyPressed:
+            handleKeyboard(param.brot, &param.event);
+            break;
+
+            //if the event is a mousewheel scroll, zoom
+        case sf::Event::MouseWheelScrolled:
+            handleZoom(param.brot, &param.event);
+            break;
+
+            //if the event is a click, drag the view:
+        case sf::Event::MouseButtonPressed:
+            handleDrag(param.brot, &param.event);
+            break;
+
+            //if the window regains focus, refresh it
+        case sf::Event::GainedFocus:
+            param.brot->refreshWindow();
+            break;
+
+            //if the event is a resize, handle it
+        case sf::Event::Resized:
+            handleResize(param.brot, &param.event);
+            break;
+
+            //if the window is closed
+        case sf::Event::Closed:
+            param.brot->close();
+            break;
+
+        default:
+            break;
+    } //end event switch
+}
+
 
 //this function handles all keyboard input
 void handleKeyboard(MandelbrotViewer *brot, sf::Event *event) {
@@ -100,17 +113,21 @@ void handleKeyboard(MandelbrotViewer *brot, sf::Event *event) {
         //if up arrow, increase iterations
         case sf::Keyboard::Up:
             brot->setIterations(brot->getIters() + 50);
-            brot->generate();
-            brot->updateMandelbrot();
-            brot->refreshWindow();
+            if (param.done) {
+                handleGenerate();
+                brot->updateMandelbrot();
+                brot->refreshWindow();
+            }
             break;
         //if down arrow, decrease iterations
         case sf::Keyboard::Down:
             if (brot->getIters() > 100)
                 brot->setIterations(brot->getIters() - 50);
-            brot->generate();
-            brot->updateMandelbrot();
-            brot->refreshWindow();
+            if (param.done) {
+                handleGenerate();
+                brot->updateMandelbrot();
+                brot->refreshWindow();
+            }
             break;
         //if right arrow, increase color_multiple until released
         case sf::Keyboard::Right:
@@ -154,14 +171,6 @@ void handleKeyboard(MandelbrotViewer *brot, sf::Event *event) {
         case sf::Keyboard::Num5:
             brot->setColorScheme(5);
             break;
-        //if it's a 6, change to color scheme 6
-        case sf::Keyboard::Num6:
-            brot->setColorScheme(6);
-            break;
-        //if it's a 7, change to color scheme 7
-        case sf::Keyboard::Num7:
-            brot->setColorScheme(7);
-            break;
         //if R, reset the mandelbrot to the starting image
         case sf::Keyboard::R:
             brot->resetMandelbrot();
@@ -173,6 +182,10 @@ void handleKeyboard(MandelbrotViewer *brot, sf::Event *event) {
         //if S, save the current image
         case sf::Keyboard::S:
             brot->saveImage();
+            break;
+        //if L, lock/unlock the color
+        case sf::Keyboard::L:
+            brot->lockColor();
             break;
         case sf::Keyboard::H:
             brot->enableOverlay(true);
@@ -342,7 +355,7 @@ void handleDrag(MandelbrotViewer *brot, sf::Event *event) {
 //animates the zoom of the viewer (so the viewer zooms while the mandelbrot is generating)
 //uses the struct param as parameters
 void zoom() {
-    param.viewer->setWindowActive(true);
+    param.brot->setWindowActive(true);
     double inc_drag_x = interpolate(param.oldc.x, param.newc.x, param.frames);
     double inc_drag_y = interpolate(param.oldc.y, param.newc.y, param.frames);
     double inc_zoom = interpolate(1.0, param.zoom, param.frames);
@@ -351,39 +364,39 @@ void zoom() {
     for (int i=0; i<param.frames; i++) {
         param.newc.x = param.oldc.x + i * inc_drag_x;
         param.newc.y = param.oldc.y + i * inc_drag_y;
-        param.viewer->changePosView(param.newc, 1 + i * inc_zoom);
-        param.viewer->refreshWindow();
+        param.brot->changePosView(param.newc, 1 + i * inc_zoom);
+        param.brot->refreshWindow();
     }
-    param.viewer->setWindowActive(false);
+    param.brot->setWindowActive(false);
 }
 
 //rotates the view until the key is released, then returns the new rotation
 double handleRotate() {
     float rotate_inc = 1.0;
-    //float rotation = param.viewer->getRotation() * 180 / PI;
+    //float rotation = param.brot->getRotation() * 180 / PI;
     float rotation = 0;
-    int framerate = param.viewer->getFramerate();
+    int framerate = param.brot->getFramerate();
 
     //set the framerate high so that it will rotate in real time
-    param.viewer->setFramerate(500);
+    param.brot->setFramerate(500);
 
     //if page up, rotate ccw
     while (sf::Keyboard::isKeyPressed(sf::Keyboard::PageUp)) {
-        param.viewer->rotateView(rotation);
-        param.viewer->refreshWindow();
+        param.brot->rotateView(rotation);
+        param.brot->refreshWindow();
         rotation += rotate_inc;
         if (rotation >= 360) rotation -= 360;
     }
 
     //if page down, rotate cw
     while (sf::Keyboard::isKeyPressed(sf::Keyboard::PageDown)) {
-        param.viewer->rotateView(rotation);
-        param.viewer->refreshWindow();
+        param.brot->rotateView(rotation);
+        param.brot->refreshWindow();
         rotation -= rotate_inc;
         if (rotation < 0) rotation += 360;
     }
 
-    param.viewer->setFramerate(framerate);
+    param.brot->setFramerate(framerate);
 
     //return the rotation in radians
     return rotation * PI / 180;
@@ -397,4 +410,32 @@ void handleResize(MandelbrotViewer *brot, sf::Event *event) {
     brot->generate();
     brot->updateMandelbrot();
     brot->refreshWindow();
+}
+
+void handleGenerate() {
+    //start checking for events in a separate thread
+    param.done = false;
+    std::thread thread(eventPoll);
+    thread.detach();
+
+    //start generating
+    param.brot->generate();
+    param.done = true; //signal the eventPoll thread to return
+}
+
+void eventPoll() {
+    while(!param.done) {
+        if (param.brot->pollEvent(param.event)) {
+            if (param.event.type == sf::Event::KeyPressed && (param.event.key.code == sf::Keyboard::Up ||
+                        param.event.key.code == sf::Keyboard::Down)) {
+                //if input is found:
+                //handle the interrupt,
+                handleEvent();
+                //send the generation an interrupt,
+                param.brot->restartGeneration(true);
+            }
+        }
+        //sleep a bit so that the processor doesn't spike checking for events
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
 }

--- a/mandelbrotExplorer.cpp
+++ b/mandelbrotExplorer.cpp
@@ -52,7 +52,7 @@ int main() {
     //main window loop
     while (brot.isOpen()) {
 
-        brot.getEvent(param.event);
+        brot.waitEvent(param.event);
 
         handleEvent();
 
@@ -108,6 +108,10 @@ void handleKeyboard(MandelbrotViewer *brot, sf::Event *event) {
     switch(event->key.code) {
         //if Q, quit and close the window
         case sf::Keyboard::Q:
+            brot->close();
+            break;
+        //if Esc, quit and close the window
+        case sf::Keyboard::Escape:
             brot->close();
             break;
         //if up arrow, increase iterations
@@ -189,7 +193,7 @@ void handleKeyboard(MandelbrotViewer *brot, sf::Event *event) {
         case sf::Keyboard::H:
             brot->enableOverlay(true);
             while(true) {
-                brot->getEvent(*event);
+                brot->waitEvent(*event);
                 if (event->type == sf::Event::KeyPressed) {
                     if (event->key.code == sf::Keyboard::H || event->key.code == sf::Keyboard::Escape) {
                         break;
@@ -431,7 +435,7 @@ void eventPoll() {
                 //handle the interrupt,
                 handleEvent();
                 //send the generation an interrupt,
-                param.brot->restartGeneration(true);
+                param.brot->restartGeneration();
             }
         }
         //sleep a bit so that the processor doesn't spike checking for events

--- a/mandelbrotExplorer.cpp
+++ b/mandelbrotExplorer.cpp
@@ -112,7 +112,7 @@ void handleKeyboard(MandelbrotViewer *brot, sf::Event *event) {
             break;
         //if up arrow, increase iterations
         case sf::Keyboard::Up:
-            brot->setIterations(brot->getIters() + 50);
+            brot->incIterations();
             if (param.done) {
                 handleGenerate();
                 brot->updateMandelbrot();
@@ -121,8 +121,7 @@ void handleKeyboard(MandelbrotViewer *brot, sf::Event *event) {
             break;
         //if down arrow, decrease iterations
         case sf::Keyboard::Down:
-            if (brot->getIters() > 100)
-                brot->setIterations(brot->getIters() - 50);
+            brot->decIterations();
             if (param.done) {
                 handleGenerate();
                 brot->updateMandelbrot();

--- a/mandelbrotViewer.cpp
+++ b/mandelbrotViewer.cpp
@@ -96,6 +96,27 @@ bool MandelbrotViewer::isOpen() {
     return window->isOpen();
 }
 
+void MandelbrotViewer::incIterations() {
+    //if iterations is in the hundreds, add 100
+    //if iterations is in the thousands, add 1000, etc.
+    int magnitude = (int) log10(max_iter);
+    unsigned int inc = pow(10, magnitude);
+    max_iter += inc;
+    initPalette();
+}
+
+void MandelbrotViewer::decIterations() {
+    //if iterations is in the hundreds, subtract 100
+    //if iterations is in the thousands, subtract 1000, etc.
+    if (max_iter > 100) {
+        int magnitude = (int) log10(max_iter);
+        unsigned int dec = pow(10, magnitude);
+        if (dec == max_iter) dec /= 10;
+        max_iter -= dec;
+        initPalette();
+    }
+}
+
 //this is a setter function to change the color scheme
 //it also handles all the regeneration and refreshing
 void MandelbrotViewer::setColorScheme(int newScheme) {
@@ -455,7 +476,7 @@ int MandelbrotViewer::escape(sf::Vector2<double> point) {
             x_square = x*x;
             y_square = y*y;
 
-            //if the magnitued is greater than 2, it will escape
+            //if the magnitude is greater than 2, it will escape
             if (x_square + y_square > 4.0) return iter;
 
             //another optimization: it checks if the new 'z' is a repeat. If so,

--- a/mandelbrotViewer.cpp
+++ b/mandelbrotViewer.cpp
@@ -32,15 +32,20 @@ MandelbrotViewer::MandelbrotViewer(int resX, int resY) {
     framerateLimit = 60;
     window->setFramerateLimit(framerateLimit);
 
-    //initialize the mandelbrot parameters
-    resetMandelbrot();
-
     //initialize the image
     texture.create(res_width, res_height);
     image.create(res_width, res_height, sf::Color::Black);
     sprite.setTexture(texture);
     scheme = 1;
-    initPalette(); 
+    
+    color_locked = false;
+    std::vector<int> pal_row(max_iter);
+    palette.push_back(pal_row);
+    palette.push_back(pal_row);
+    palette.push_back(pal_row);
+
+    //initialize the mandelbrot parameters
+    resetMandelbrot();
 
     //initialize the font for the overlay
 	if (font.loadFromFile("cour.ttf"));
@@ -57,7 +62,7 @@ MandelbrotViewer::MandelbrotViewer(int resX, int resY) {
     max_threads = std::thread::hardware_concurrency();
 
     //disable repeated keys
-    window->setKeyRepeatEnabled(false);
+//    window->setKeyRepeatEnabled(false);
     rotation = 0;
 }
 
@@ -76,9 +81,14 @@ sf::Vector2f MandelbrotViewer::getMandelbrotCenter() {
     return center;
 }
 
-//gets the next event from the viewer
+//wait for and return the next event from the viewer
 bool MandelbrotViewer::getEvent(sf::Event& event) {
     return window->waitEvent(event);
+}
+
+//poll for events from the viewer
+bool MandelbrotViewer::pollEvent(sf::Event& event) {
+    return window->pollEvent(event);
 }
 
 //checks if the window is open
@@ -105,6 +115,19 @@ void MandelbrotViewer::setRotation(double radians) {
     resetView();
     updateMandelbrot();
     refreshWindow();
+}
+
+void MandelbrotViewer::lockColor() {
+    if (color_locked) {
+        color_locked = false;
+        initPalette();
+        changeColor();
+        updateMandelbrot();
+        refreshWindow();
+        color_max = max_iter;
+    } else {
+        color_locked = true;
+    }
 }
 
 //Functions to change parameters of mandelbrot
@@ -179,22 +202,35 @@ void MandelbrotViewer::resizeWindow(int new_x, int new_y) {
 //generate the mandelbrot
 void MandelbrotViewer::generate() {
 
-    //make sure it starts at line 0
-    nextLine = 0;
+    bool done = false;
+    restart_gen = false;
 
-    //create the thread pool
-    std::vector<std::thread> threadPool;
-    for (int i=0; i<max_threads; i++) {
-        threadPool.push_back(std::thread(&MandelbrotViewer::genLine, this));
-    }
+    while (!done) {
+        //make sure it starts at line 0
+        nextLine = 0;
+        finished_threads = 0;
 
-    //join the threads
-    for (int i=0; i<max_threads; i++) {
-        threadPool[i].join();
+        //create the thread pool
+        std::vector<std::thread> threadPool;
+        for (int i=0; i<max_threads; i++) {
+            threadPool.push_back(std::thread(&MandelbrotViewer::genLine, this));
+        }
+
+        //wait for the threads to finish
+        for (int i=0; i<max_threads; i++) {
+            threadPool[i].join();
+        }
+
+        //when the threads finish prematurely, reset needed variables and restart generation
+        if (restart_gen) {
+            done = false;
+            restart_gen = false;
+        } else done = true;
     }
 
     //reset last_max_iter to the new max_iter
     last_max_iter = max_iter;
+
 }
 
 //this is a private worker thread function. Each thread picks the next ungenerated
@@ -215,9 +251,9 @@ void MandelbrotViewer::genLine() {
         row = nextLine++; //get the next ungenerated line
         mutex1.unlock();
 
-        //if all the rows have been generated, stop it from generating outside the bounds
-        //of the image
-        if (row >= res_height) return;
+        //stop generating if it has reached the last row or has been
+        //signaled to stop
+        if (row >= res_height || restart_gen) return;
 
         //calculate the row height in the complex plane
         point.y = area.top + row * y_inc;
@@ -225,13 +261,13 @@ void MandelbrotViewer::genLine() {
         //now loop through and generate all the pixels in that row
         for (column = 0; column < res_width; column++) {
 
-            // Check if we increased iterations and if the pixel already diverged
-            if ( last_max_iter < max_iter && image_array[row][column] < last_max_iter ) {
+            //check if we increased iterations and if the pixel already diverged
+            if (last_max_iter < max_iter && image_array[row][column] < last_max_iter) {
                 iter = image_array[row][column];
-            } // Check if we decreased iterations and if the pixel already converged
-            else if ( last_max_iter > max_iter && image_array[row][column] > max_iter) {
+            } //check if we decreased iterations and if the pixel already converged
+            else if (last_max_iter > max_iter && image_array[row][column] > max_iter) {
                 iter = image_array[row][column];
-            } // Check if we zoomed or didn't change iterations
+            } //check if we zoomed or didn't change iterations
             else {
                 //calculate the next x coordinate of the complex plane
                 point.x = area.left + column * x_inc;
@@ -261,6 +297,8 @@ void MandelbrotViewer::resetMandelbrot() {
     last_max_iter = 100;
     color_multiple = 1;
     rotation = 0;
+    color_locked = false;
+    initPalette();
 }
 
 //refreshes the window: clear, draw, display
@@ -302,7 +340,6 @@ void MandelbrotViewer::saveImage() {
 
     //save the image and print confirmation
     image.saveToFile(filename);
-    std::cout << "Saved image to " << filename << std::endl;
 }
 
 //enables an overlay that dims the screen and displays controls/stats/etc.
@@ -344,6 +381,10 @@ void MandelbrotViewer::enableOverlay(bool enable) {
         ss << std::defaultfloat;
         int zoom_level = log2(2.0/area.width);
         ss << "\n\nZoom level: " << zoom_level;
+        if (color_locked)
+            ss << "\t\t\t\t\t\tColor is locked";
+        else
+            ss << "\t\t\t\t\t\tColor is unlocked";
 		ss << "\n\nIterations: " << max_iter << std::fixed << std::setprecision(0);
         ss << "\n\nRotation: " << angle << " degrees";
 
@@ -429,7 +470,7 @@ int MandelbrotViewer::escape(sf::Vector2<double> point) {
 
 //findColor uses the number of iterations passed to it to look up a color in the palette
 sf::Color MandelbrotViewer::findColor(int iter) {
-    int i = fmod(iter * color_multiple, 255);
+    int i = (int) fmod(iter * color_multiple, palette[0].size());
     sf::Color color;
     if (iter >= max_iter) color = sf::Color::Black;
     else {
@@ -477,100 +518,67 @@ sf::Vector2<double> MandelbrotViewer::rotate(sf::Vector2<double> rect) {
     return rect;
 }
 
-//This is for initPalette, it makes sure the given number is between 0 and 255
-int coerce(int number) {
-    if (number > 255) number = 255;
-    else if (number < 0) number = 0;
-    return number;
-}
-
 //Sets up the palette array
 void MandelbrotViewer::initPalette() {
+
+    if (!color_locked) {
+        palette[0].resize(max_iter);
+        palette[1].resize(max_iter);
+        palette[2].resize(max_iter);
+        color_max = max_iter;
+    }
+
     //define some non-standard colors
     sf::Color orange;
     orange.r = 255;
     orange.g = 165;
     orange.b = 0;
-    sf::Color pink;
-    pink.r = 255;
-    pink.g = 135;
-    pink.b = 135;
-    sf::Color dark_red;
-    dark_red.r = 209;
-    dark_red.g = 2;
-    dark_red.b = 2;
-    sf::Color dark_green;
-    dark_green.r = 8;
-    dark_green.g = 172;
-    dark_green.b = 8;
-    sf::Color light_green;
-    light_green.r = 115;
-    light_green.g = 255;
-    light_green.b = 115;
+
     switch (scheme) {
         //scheme one is black:blue:white:orange:black
         case 1:
-            smoosh(sf::Color::Black, sf::Color::Blue, 0, 64);
-            smoosh(sf::Color::Blue, sf::Color::White, 64, 144);
-            smoosh(sf::Color::White, orange, 144, 196);
-            smoosh(orange, sf::Color::Black, 196, 256);
+            smoosh(sf::Color::Black, sf::Color::Blue, 0, 0.25);
+            smoosh(sf::Color::Blue, sf::Color::White, 0.25, 0.56);
+            smoosh(sf::Color::White, orange, 0.56, 0.75);
+            smoosh(orange, sf::Color::Black, 0.75, 1);
             break;
-        //scheme two is black:green:blue:black
+        //scheme two is black:red:orange:black
         case 2:
-            smoosh(sf::Color::Black, sf::Color::Green, 0, 85);
-            smoosh(sf::Color::Green, sf::Color::Blue, 85, 170);
-            smoosh(sf::Color::Blue, sf::Color::Black, 170, 256);
+            smoosh(sf::Color::Black, sf::Color::Red, 0, 0.7);
+            smoosh(sf::Color::Red, orange, 0.7, 0.84);
+            smoosh(orange, sf::Color::Black, 0.84, 1);
             break;
-        //scheme three is black:red:orange:black
+        //scheme three is black:cyan:white:black
         case 3:
-            smoosh(sf::Color::Black, sf::Color::Red, 0, 180);
-            smoosh(sf::Color::Red, orange, 180, 215);
-            smoosh(orange, sf::Color::Black, 215, 256);
+            smoosh(sf::Color::Black, sf::Color::Cyan, 0, 0.43);
+            smoosh(sf::Color::Cyan, sf::Color::White, 0.43, 0.86);
+            smoosh(sf::Color::White, sf::Color::Black, 0.86, 1);
             break;
-        //scheme four is black:cyan:white:black
+        //scheme four is red:orange:yellow:green:blue:magenta:red
         case 4:
-            smoosh(sf::Color::Black, sf::Color::Cyan, 0, 110);
-            smoosh(sf::Color::Cyan, sf::Color::White, 110, 220);
-            smoosh(sf::Color::White, sf::Color::Black, 220, 256);
+            smoosh(sf::Color::Red, orange, 0, 0.17);
+            smoosh(orange, sf::Color::Yellow, 0.17, 0.33);
+            smoosh(sf::Color::Yellow, sf::Color::Green, 0.33, 0.5);
+            smoosh(sf::Color::Green, sf::Color::Blue, 0.5, 0.67);
+            smoosh(sf::Color::Blue, sf::Color::Magenta, 0.67, 0.83);
+            smoosh(sf::Color::Magenta, sf::Color::Red, 0.83, 1);
             break;
-        //scheme five is red:orange:yellow:green:blue:magenta:red
+        //scheme five is black:white
         case 5:
-            smoosh(sf::Color::Red, orange, 0, 42);
-            smoosh(orange, sf::Color::Yellow, 42, 84);
-            smoosh(sf::Color::Yellow, sf::Color::Green, 84, 127);
-            smoosh(sf::Color::Green, sf::Color::Blue, 127, 170);
-            smoosh(sf::Color::Blue, sf::Color::Magenta, 170, 212);
-            smoosh(sf::Color::Magenta, sf::Color::Red, 212, 256);
+            smoosh(sf::Color::White, sf::Color::Black, 0, 1);
             break;
-        //scheme six is dark_red:pink, then dark_green:light_green
-        case 6:
-            smoosh(dark_red, pink, 0, 128);
-            smoosh(dark_green, light_green, 128, 256);
-            break;
-        //scheme seven is smoky... black:white
-        case 7:
-            smoosh(sf::Color::White, sf::Color::Black, 0, 256);
-            break;
-        default:
-            int r, g, b;
-            for (int i = 0; i <= 255; i++) {
-                r = (int) (23.45 - 1.880*i + 0.0461*i*i - 0.000152*i*i*i);
-                g = (int) (17.30 - 0.417*i + 0.0273*i*i - 0.000101*i*i*i);
-                b = (int) (25.22 + 7.902*i - 0.0681*i*i + 0.000145*i*i*i);
-
-                palette[0][i] = coerce(r);
-                palette[1][i] = coerce(g);
-                palette[2][i] = coerce(b);
-            }
     }
 }
 
 //Smooshes two colors together, and writes them to the palette in the specified range
-void MandelbrotViewer::smoosh(sf::Color c1, sf::Color c2, int min, int max) {
+void MandelbrotViewer::smoosh(sf::Color c1, sf::Color c2, float min_per, float max_per) {
+    int min = (int) (min_per * color_max);
+    int max = (int) (max_per * color_max);
     int range = max-min;
-    float r_inc = interpolate(c1.r, c2.r, range);
-    float g_inc = interpolate(c1.g, c2.g, range);
-    float b_inc = interpolate(c1.b, c2.b, range);
+
+    double r_inc = interpolate(c1.r, c2.r, range);
+    double g_inc = interpolate(c1.g, c2.g, range);
+    double b_inc = interpolate(c1.b, c2.b, range);
 
     //loop through the palette setting new colors
     for (int i=0; i < range; i++) {

--- a/mandelbrotViewer.h
+++ b/mandelbrotViewer.h
@@ -32,7 +32,9 @@ class MandelbrotViewer {
         bool isOpen();
         
         //Setter functions:
-        void setIterations(int iter) {max_iter = iter; if(!color_locked) initPalette();}
+        void incIterations();
+        void decIterations();
+        void setIterations(int iter) {max_iter = iter; initPalette();}
         void setColorMultiple(double mult) {color_multiple = mult;}
         void setFramerate(int rate) {framerateLimit = rate;}
         void setColorScheme(int newScheme);
@@ -73,16 +75,15 @@ class MandelbrotViewer {
         int nextLine;
         int finished_threads;
 
-        //These are pointers to each instance's window and view
-        //since we can't initialize them yet
-        sf::RenderWindow *window;
-        sf::View *view;
-
         sf::Sprite sprite;
         sf::Image image;
         sf::Texture texture;
         sf::Font font;
 
+        //These are pointers to each instance's window and view
+        //since we can't initialize them yet
+        sf::RenderWindow *window;
+        sf::View *view;
 
         //Parameters to generate the mandelbrot:
         bool restart_gen; //set to true to stop generation before it's finished

--- a/mandelbrotViewer.h
+++ b/mandelbrotViewer.h
@@ -26,7 +26,7 @@ class MandelbrotViewer {
         sf::Vector2i getMousePosition();
         sf::Vector2f getViewCenter() {return view->getCenter();}
         sf::Vector2f getMandelbrotCenter();
-        bool getEvent(sf::Event&);
+        bool waitEvent(sf::Event&);
         bool pollEvent(sf::Event&);
         bool isColorLocked() {return color_locked;}
         bool isOpen();
@@ -39,7 +39,7 @@ class MandelbrotViewer {
         void setFramerate(int rate) {framerateLimit = rate;}
         void setColorScheme(int newScheme);
         void setRotation(double radians);
-        void restartGeneration(bool stop) {restart_gen = true;};
+        void restartGeneration() {restart_gen = true;}
         void lockColor();
         
         //Functions to change parameters for mandelbrot generation:
@@ -97,7 +97,6 @@ class MandelbrotViewer {
         //this changes how the colors are displayed
         double color_multiple;
         bool color_locked;
-        unsigned int color_max;
         int scheme;
 
         //Holds the maximum number of concurrent threads suppported by the current CPU

--- a/mandelbrotViewer.h
+++ b/mandelbrotViewer.h
@@ -27,14 +27,18 @@ class MandelbrotViewer {
         sf::Vector2f getViewCenter() {return view->getCenter();}
         sf::Vector2f getMandelbrotCenter();
         bool getEvent(sf::Event&);
+        bool pollEvent(sf::Event&);
+        bool isColorLocked() {return color_locked;}
         bool isOpen();
         
         //Setter functions:
-        void setIterations(int iter) {last_max_iter = max_iter; max_iter = iter;}
+        void setIterations(int iter) {max_iter = iter; if(!color_locked) initPalette();}
         void setColorMultiple(double mult) {color_multiple = mult;}
         void setFramerate(int rate) {framerateLimit = rate;}
         void setColorScheme(int newScheme);
         void setRotation(double radians);
+        void restartGeneration(bool stop) {restart_gen = true;};
+        void lockColor();
         
         //Functions to change parameters for mandelbrot generation:
         void changeColor();
@@ -67,6 +71,7 @@ class MandelbrotViewer {
         int res_width;
         int framerateLimit;
         int nextLine;
+        int finished_threads;
 
         //These are pointers to each instance's window and view
         //since we can't initialize them yet
@@ -78,7 +83,9 @@ class MandelbrotViewer {
         sf::Texture texture;
         sf::Font font;
 
+
         //Parameters to generate the mandelbrot:
+        bool restart_gen; //set to true to stop generation before it's finished
         
         //this is the area of the complex plane to generate
         sf::Rect<double> area;
@@ -88,6 +95,8 @@ class MandelbrotViewer {
         
         //this changes how the colors are displayed
         double color_multiple;
+        bool color_locked;
+        unsigned int color_max;
         int scheme;
 
         //Holds the maximum number of concurrent threads suppported by the current CPU
@@ -98,8 +107,9 @@ class MandelbrotViewer {
 
         //maximum number of iterations to check for. Higher values are slower,
         //but more precise
-        int max_iter;
-        int last_max_iter;
+        unsigned int max_iter;
+        unsigned int last_max_iter;
+
 
         //Functions:
         
@@ -123,9 +133,9 @@ class MandelbrotViewer {
 
         //initialize the color palette. Having a palette helps avoid regenerating the
         //color scheme each time it is needed
-        int palette[3][256];
+        std::vector< std::vector<int> > palette;
         void initPalette();
-        void smoosh(sf::Color c1, sf::Color c2, int min, int max);
+        void smoosh(sf::Color c1, sf::Color c2, float min, float max);
 };
 
 #endif


### PR DESCRIPTION
closes #18 and #12 

While the mandelbrot is generating after an iteration change, it can be interrupted to change it again before it's done. That way there's no need to wait until it's done generating iterations just to change it again.

Iterations and colors now scale with depth. So, the higher the iterations the faster it will be increased. Colors (left and right arrow) are dependent on max_iters. So the more iterations, the slower colors move. If colors move too slowly, you can press 'L' at a lower iteration level to "lock" the colors from change more. Press 'L' again to unlock.
